### PR TITLE
Add basic client portal with collapsible side menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # portalclientespf
-portal clientes pf - teste
+
+Portal Clientes PF - teste.
+
+## Execução
+
+```bash
+python app.py
+```
+
+Abra o navegador em [http://localhost:8000](http://localhost:8000) para acessar o portal.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,15 @@
+import http.server
+import socketserver
+
+PORT = 8000
+DIRECTORY = "templates"
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=DIRECTORY, **kwargs)
+
+
+if __name__ == "__main__":
+    with socketserver.TCPServer(("", PORT), Handler) as httpd:
+        print(f"Serving at port {PORT}")
+        httpd.serve_forever()

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <title>Portal Cliente PF</title>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+</head>
+<body>
+  <!-- Side navigation -->
+  <ul id="slide-out" class="sidenav sidenav-fixed">
+    <li>
+      <div class="user-view">
+        <div class="background blue"></div>
+        <span class="white-text name">Portal Cliente PF</span>
+      </div>
+    </li>
+    <li>
+      <ul class="collapsible">
+        <li>
+          <div class="collapsible-header"><i class="material-icons">people</i>Clientes</div>
+          <div class="collapsible-body">
+            <ul>
+              <li><a href="#">Consultar Clientes</a></li>
+              <li><a href="#">Consultar clientes por nº de Cartão</a></li>
+              <li><a href="#">Consultar Relacionamento do Cliente x Banco</a></li>
+              <li><a href="#">Consultar Clientes com Reclamações</a></li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </li>
+  </ul>
+
+  <main style="margin-left: 300px; padding: 20px;">
+    <h1>Bem-vindo ao Portal Cliente PF</h1>
+    <p>Selecione uma opção no menu.</p>
+  </main>
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('.sidenav');
+      M.Sidenav.init(elems);
+      var collapses = document.querySelectorAll('.collapsible');
+      M.Collapsible.init(collapses);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple Python HTTP server
- create Materialize-based index with collapsible 'Clientes' menu
- document how to run the portal

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689be468998c832691ce0002d10c8cb7